### PR TITLE
make relation customizable and set default values for `

### DIFF
--- a/src/Manager/DefaultManager.php
+++ b/src/Manager/DefaultManager.php
@@ -73,14 +73,16 @@ class DefaultManager implements ManagerInterface, DcaAwareInterface
         /** @var TagModel $adapter */
         $adapter = $this->framework->getAdapter(TagModel::class);
 
-        if (($model = $adapter->findByPk($value)) === null) {
+        if (($model = $adapter->findByPk($value)) === null)
+        {
             return null;
         }
 
         $criteria = $this->getCriteria($criteria);
 
         // Check the source
-        if ($model->source !== $criteria['source']) {
+        if ($model->source !== $criteria['source'])
+        {
             return null;
         }
 
@@ -132,11 +134,17 @@ class DefaultManager implements ManagerInterface, DcaAwareInterface
         /** @var TagModel $adapter */
         $adapter = $this->framework->getAdapter(TagModel::class);
 
-        $config['relation'] = ['type' => 'haste-ManyToMany', 'load' => 'lazy', 'table' => $adapter->getTable()];
+        $config['relation'] = array_merge(
+            is_array($config['relation']) ? $config['relation'] : [],
+            ['type' => 'haste-ManyToMany', 'load' => 'lazy', 'table' => $adapter->getTable()]
+        );
 
-        if (isset($config['save_callback']) && is_array($config['save_callback'])) {
+        if (isset($config['save_callback']) && is_array($config['save_callback']))
+        {
             array_unshift($config['save_callback'], ['codefog_tags.listener.tag_manager', 'onFieldSave']);
-        } else {
+        }
+        else
+        {
             $config['save_callback'][] = ['codefog_tags.listener.tag_manager', 'onFieldSave'];
         }
     }
@@ -146,12 +154,14 @@ class DefaultManager implements ManagerInterface, DcaAwareInterface
      */
     public function saveDcaField(string $value, DataContainer $dc): string
     {
-        $value = StringUtil::deserialize($value, true);
+        $value    = StringUtil::deserialize($value, true);
         $criteria = $this->getCriteria();
 
         /** @var array $value */
-        foreach ($value as $k => $v) {
-            if ($this->find($v, $criteria) !== null) {
+        foreach ($value as $k => $v)
+        {
+            if ($this->find($v, $criteria) !== null)
+            {
                 continue;
             }
 
@@ -171,9 +181,9 @@ class DefaultManager implements ManagerInterface, DcaAwareInterface
     private function createTag(string $value): Tag
     {
         /** @var TagModel $model */
-        $model = $this->framework->createInstance(TagModel::class);
+        $model         = $this->framework->createInstance(TagModel::class);
         $model->tstamp = time();
-        $model->name = $value;
+        $model->name   = $value;
         $model->source = $this->alias;
         $model->save();
 
@@ -189,7 +199,7 @@ class DefaultManager implements ManagerInterface, DcaAwareInterface
      */
     private function getCriteria(array $criteria = []): array
     {
-        $criteria['source'] = $this->alias;
+        $criteria['source']      = $this->alias;
         $criteria['sourceTable'] = $this->sourceTable;
         $criteria['sourceField'] = $this->sourceField;
 

--- a/src/Resources/contao/dca/tl_cfg_tag.php
+++ b/src/Resources/contao/dca/tl_cfg_tag.php
@@ -90,7 +90,7 @@ $GLOBALS['TL_DCA']['tl_cfg_tag'] = [
                 'maxlength' => 255,
                 'tl_class' => 'w50',
             ],
-            'sql' => ['type' => 'string', 'length' => 64],
+            'sql' => ['type' => 'string', 'length' => 64, 'default' => ''],
         ],
         'source' => [
             'label' => &$GLOBALS['TL_LANG']['tl_cfg_tag']['source'],
@@ -100,7 +100,7 @@ $GLOBALS['TL_DCA']['tl_cfg_tag'] = [
             'options_callback' => ['codefog_tags.listener.data_container.tag', 'getSources'],
             'reference' => &$GLOBALS['TL_LANG']['tl_cfg_tag']['sourceRef'],
             'eval' => ['mandatory' => true, 'includeBlankOption' => true, 'tl_class' => 'w50'],
-            'sql' => ['type' => 'string', 'length' => 64],
+            'sql' => ['type' => 'string', 'length' => 64, 'default' => 'NULL'],
         ],
     ],
 ];


### PR DESCRIPTION
Hey there,

we are working on a news-bundle that make usage of the `tags-bundle`. 
First of all we got an sql error, when creating new tags, cause default values should be given. 
Second change is in DefaultManager::updateDcaField for the relation configuration, that should be overwritable. Can you have an eye on this changes and merge them please?

Btw. thanks for this bundle! :+1: 