### PR TITLE
added alias field, callback and tags_title inserttag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "heimrichhannot/tags-bundle",
+    "name": "codefog/tags-bundle",
     "description": "Tags bundle for Contao Open Source CMS",
     "keywords": ["contao", "tag", "tags", "tagging"],
     "type": "contao-bundle",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "codefog/tags-bundle",
+    "name": "heimrichhannot/tags-bundle",
     "description": "Tags bundle for Contao Open Source CMS",
     "keywords": ["contao", "tag", "tags", "tagging"],
     "type": "contao-bundle",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,11 @@
     },
     "autoload": {
         "psr-4": {
-            "Codefog\\TagsBundle\\": "src",
+            "Codefog\\TagsBundle\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Codefog\\TagsBundle\\Test\\": "tests"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Codefog\\TagsBundle\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
+            "Codefog\\TagsBundle\\": "src",
             "Codefog\\TagsBundle\\Test\\": "tests"
         }
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
          backupGlobals="false"
          colors="true"
          processIsolation="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/EventListener/DataContainer/TagListener.php
+++ b/src/EventListener/DataContainer/TagListener.php
@@ -66,73 +66,60 @@ class TagListener
     }
 
     /**
-     * Get the manager.
-     *
-     * @param string $alias
-     *
-     * @return ManagerInterface
-     */
-    private function getManager(string $alias): ManagerInterface
-    {
-        return $this->registry->get($alias);
-    }
-
-    /**
-     * Auto-generate the tag alias if it has not been set yet
+     * Auto-generate the tag alias if it has not been set yet.
      *
      * @param mixed         $value
      * @param DataContainer $dc
      *
-     * @return mixed
-     *
      * @throws \Exception
+     *
+     * @return mixed
      */
-    public function generateAlias($value, DataContainer $dc)
+    public function generateAlias($value, DataContainer $dc): ?string
     {
         $autoAlias = false;
 
         // Generate alias if there is none
-        if ($value == '')
-        {
+        if ($value === '') {
             $autoAlias = true;
-            $value     = \StringUtil::generateAlias($dc->activeRecord->name);
+            $value = \StringUtil::generateAlias($dc->activeRecord->name);
         }
 
-        $alias = \Database::getInstance()->prepare("SELECT id FROM tl_cfg_tag WHERE alias=? AND source=?")
+        $statement = new \Database\Statement(\System::getContainer()->get('database_connection'), false);
+
+        $alias = $statement->prepare('SELECT id FROM tl_cfg_tag WHERE alias=? AND source=?')
             ->execute($value, $dc->activeRecord->source);
 
         // Check whether the alias exists
-        if ($alias->numRows > 1 && !$autoAlias)
-        {
+        if ($alias->numRows > 1 && !$autoAlias) {
             throw new \Exception(sprintf($GLOBALS['TL_LANG']['ERR']['aliasExists'], $value));
         }
 
         // Add ID to alias
-        if ($alias->numRows && $autoAlias)
-        {
-            $value .= '-' . $dc->id;
+        if ($alias->numRows && $autoAlias) {
+            $value .= '-'.$dc->id;
         }
 
         return $value;
     }
 
     /**
-     * Automatically generate the folder URL aliases
+     * Automatically generate the folder URL aliases.
      *
-     * @param array $buttons
+     * @param array          $buttons
      * @param \DataContainer $dc
      *
      * @return array
      */
-    public function addAliasButton($buttons, \DataContainer $dc)
+    public function addAliasButton($buttons, \DataContainer $dc): array
     {
         // Generate the aliases
-        if (\Input::post('FORM_SUBMIT') == 'tl_select' && isset($_POST['alias'])) {
+        if (\Input::post('FORM_SUBMIT') === 'tl_select' && isset($_POST['alias'])) {
             /** @var \Symfony\Component\HttpFoundation\Session\SessionInterface $session */
             $session = \System::getContainer()->get('session');
 
             $session = $session->all();
-            $ids     = $session['CURRENT']['IDS'];
+            $ids = $session['CURRENT']['IDS'];
 
             foreach ($ids as $id) {
                 /** @var TagModel $adapter */
@@ -142,7 +129,7 @@ class TagListener
                     continue;
                 }
 
-                $dc->id           = $id;
+                $dc->id = $id;
                 $dc->activeRecord = $tag;
 
                 $alias = '';
@@ -157,7 +144,7 @@ class TagListener
                 }
 
                 // The alias has not changed
-                if ($alias == $tag->alias) {
+                if ($alias === $tag->alias) {
                     continue;
                 }
 
@@ -166,7 +153,8 @@ class TagListener
                 $versions->initialize();
 
                 // Store the new alias
-                \Database::getInstance()->prepare("UPDATE tl_cfg_tag SET alias=? WHERE id=?")->execute($alias, $id);
+                $statement = new \Database\Statement(\System::getContainer()->get('database_connection'), false);
+                $statement->prepare('UPDATE tl_cfg_tag SET alias=? WHERE id=?')->execute($alias, $id);
 
                 // Create a new version
                 $versions->create();
@@ -176,8 +164,20 @@ class TagListener
         }
 
         // Add the button
-        $buttons['alias'] = '<button type="submit" name="alias" id="alias" class="tl_submit" accesskey="a">' . $GLOBALS['TL_LANG']['MSC']['aliasSelected'] . '</button> ';
+        $buttons['alias'] = '<button type="submit" name="alias" id="alias" class="tl_submit" accesskey="a">'.$GLOBALS['TL_LANG']['MSC']['aliasSelected'].'</button> ';
 
         return $buttons;
+    }
+
+    /**
+     * Get the manager.
+     *
+     * @param string $alias
+     *
+     * @return ManagerInterface
+     */
+    private function getManager(string $alias): ManagerInterface
+    {
+        return $this->registry->get($alias);
     }
 }

--- a/src/EventListener/DataContainer/TagListener.php
+++ b/src/EventListener/DataContainer/TagListener.php
@@ -48,10 +48,10 @@ class TagListener
     /**
      * Generate the label.
      *
-     * @param array $row
-     * @param string $label
+     * @param array         $row
+     * @param string        $label
      * @param DataContainer $dc
-     * @param array $args
+     * @param array         $args
      *
      * @return array
      */
@@ -77,7 +77,8 @@ class TagListener
     }
 
     /**
-     * Set the existing aliases
+     * Set the existing aliases.
+     *
      * @param $value
      * @param DataContainer $dc
      */
@@ -93,6 +94,7 @@ class TagListener
      *
      * @param $value
      * @param DataContainer $dc
+     *
      * @return Result
      */
     public function getExistingAliases($value, DataContainer $dc): Result
@@ -114,8 +116,10 @@ class TagListener
      *
      * @param $value
      * @param DataContainer $dc
-     * @return null|string
+     *
      * @throws \Exception
+     *
+     * @return null|string
      */
     public function generateAlias($value, DataContainer $dc): ?string
     {
@@ -124,7 +128,7 @@ class TagListener
         // Generate alias if there is none
         if ($value === '') {
             $autoAlias = true;
-            $value     = StringUtil::generateAlias($dc->activeRecord->name);
+            $value = StringUtil::generateAlias($dc->activeRecord->name);
         }
 
         $existingAliases = $this->getExistingAliases($value, $dc);
@@ -136,7 +140,7 @@ class TagListener
 
         // Add ID to alias
         if ($existingAliases->numRows && $autoAlias) {
-            $value .= '-' . $dc->id;
+            $value .= '-'.$dc->id;
         }
 
         $this->existingAliases = null;
@@ -149,7 +153,7 @@ class TagListener
      *
      * @codeCoverageIgnore
      *
-     * @param array $buttons
+     * @param array          $buttons
      * @param \DataContainer $dc
      *
      * @return array
@@ -162,7 +166,7 @@ class TagListener
             $session = System::getContainer()->get('session');
 
             $session = $session->all();
-            $ids     = $session['CURRENT']['IDS'];
+            $ids = $session['CURRENT']['IDS'];
 
             foreach ($ids as $id) {
                 /** @var TagModel $adapter */
@@ -172,7 +176,7 @@ class TagListener
                     continue;
                 }
 
-                $dc->id           = $id;
+                $dc->id = $id;
                 $dc->activeRecord = $tag;
 
                 $alias = '';
@@ -207,7 +211,7 @@ class TagListener
         }
 
         // Add the button
-        $buttons['alias'] = '<button type="submit" name="alias" id="alias" class="tl_submit" accesskey="a">' . $GLOBALS['TL_LANG']['MSC']['aliasSelected'] . '</button>';
+        $buttons['alias'] = '<button type="submit" name="alias" id="alias" class="tl_submit" accesskey="a">'.$GLOBALS['TL_LANG']['MSC']['aliasSelected'].'</button>';
 
         return $buttons;
     }

--- a/src/EventListener/DataContainer/TagListener.php
+++ b/src/EventListener/DataContainer/TagListener.php
@@ -147,6 +147,8 @@ class TagListener
     /**
      * Automatically generate the folder URL aliases.
      *
+     * @codeCoverageIgnore
+     *
      * @param array $buttons
      * @param \DataContainer $dc
      *

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\EventListener;
 
 use Codefog\TagsBundle\Model\TagModel;
@@ -17,7 +25,7 @@ class InsertTagsListener
      * @var array
      */
     private $supportedTags = [
-        'tags_title'
+        'tags_title',
     ];
 
     /**
@@ -40,7 +48,7 @@ class InsertTagsListener
     public function onReplaceInsertTags($tag)
     {
         $elements = explode('::', $tag);
-        $key      = strtolower($elements[0]);
+        $key = strtolower($elements[0]);
 
         if (in_array($key, $this->supportedTags, true)) {
             return $this->replaceInsertTag($key, $elements);
@@ -49,12 +57,11 @@ class InsertTagsListener
         return false;
     }
 
-
     /**
      * Replaces a tags-related insert tag.
      *
      * @param string $insertTag
-     * @param array $elements
+     * @param array  $elements
      *
      * @return string
      */
@@ -63,18 +70,18 @@ class InsertTagsListener
         $this->framework->initialize();
 
         $criteria['source'] = $elements[1];
-        $idOrAlias          = $elements[2];
+        $idOrAlias = $elements[2];
 
         /** @var TagModel $adapter */
         $adapter = $this->framework->getAdapter(TagModel::class);
 
         if (is_numeric($idOrAlias)) {
             $criteria = [
-                'values' => [$idOrAlias]
+                'values' => [$idOrAlias],
             ];
         } else {
             $criteria = [
-                'aliases' => [$idOrAlias]
+                'aliases' => [$idOrAlias],
             ];
         }
 
@@ -89,7 +96,7 @@ class InsertTagsListener
      * Generates the replacement string.
      *
      * @param Collection $tags
-     * @param string $insertTag
+     * @param string     $insertTag
      *
      * @return string
      */
@@ -98,7 +105,6 @@ class InsertTagsListener
         switch ($insertTag) {
             case 'tags_title':
                 return $tags->first()->name;
-                break;
         }
 
         return '';

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Codefog\TagsBundle\EventListener;
+
+use Codefog\TagsBundle\Model\TagModel;
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Model\Collection;
+
+class InsertTagsListener
+{
+    /**
+     * @var ContaoFrameworkInterface
+     */
+    private $framework;
+
+    /**
+     * @var array
+     */
+    private $supportedTags = [
+        'tags_title'
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param ContaoFrameworkInterface $framework
+     */
+    public function __construct(ContaoFrameworkInterface $framework)
+    {
+        $this->framework = $framework;
+    }
+
+    /**
+     * Replaces tags insert tags.
+     *
+     * @param string $tag
+     *
+     * @return string|false
+     */
+    public function onReplaceInsertTags($tag)
+    {
+        $elements = explode('::', $tag);
+        $key      = strtolower($elements[0]);
+
+        if (in_array($key, $this->supportedTags, true)) {
+            return $this->replaceInsertTag($key, $elements);
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Replaces a tags-related insert tag.
+     *
+     * @param string $insertTag
+     * @param array $elements
+     *
+     * @return string
+     */
+    private function replaceInsertTag($insertTag, array $elements)
+    {
+        $this->framework->initialize();
+
+        $criteria['source'] = $elements[1];
+        $idOrAlias          = $elements[2];
+
+        /** @var TagModel $adapter */
+        $adapter = $this->framework->getAdapter(TagModel::class);
+
+        if (is_numeric($idOrAlias)) {
+            $criteria = [
+                'values' => [$idOrAlias]
+            ];
+        } else {
+            $criteria = [
+                'aliases' => [$idOrAlias]
+            ];
+        }
+
+        if (null === ($tags = $adapter->findByCriteria($criteria))) {
+            return '';
+        }
+
+        return $this->generateReplacement($tags, $insertTag);
+    }
+
+    /**
+     * Generates the replacement string.
+     *
+     * @param Collection $tags
+     * @param string $insertTag
+     *
+     * @return string
+     */
+    private function generateReplacement(Collection $tags, $insertTag)
+    {
+        switch ($insertTag) {
+            case 'tags_title':
+                return $tags->first()->name;
+                break;
+        }
+
+        return '';
+    }
+}

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -106,7 +106,5 @@ class InsertTagsListener
             case 'tags_title':
                 return $tags->first()->name;
         }
-
-        return '';
     }
 }

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -12,7 +12,7 @@ namespace Codefog\TagsBundle\EventListener;
 
 use Codefog\TagsBundle\Model\TagModel;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
-use Model\Collection;
+use Contao\Model\Collection;
 
 class InsertTagsListener
 {

--- a/src/Manager/DefaultManager.php
+++ b/src/Manager/DefaultManager.php
@@ -165,6 +165,22 @@ class DefaultManager implements ManagerInterface, DcaAwareInterface
     }
 
     /**
+     * Get the criteria with necessary data.
+     *
+     * @param array $criteria
+     *
+     * @return array
+     */
+    protected function getCriteria(array $criteria = []): array
+    {
+        $criteria['source'] = $this->alias;
+        $criteria['sourceTable'] = $this->sourceTable;
+        $criteria['sourceField'] = $this->sourceField;
+
+        return $criteria;
+    }
+
+    /**
      * Create the tag.
      *
      * @param string $value
@@ -181,21 +197,5 @@ class DefaultManager implements ManagerInterface, DcaAwareInterface
         $model->save();
 
         return ModelCollection::createTagFromModel($model);
-    }
-
-    /**
-     * Get the criteria with necessary data.
-     *
-     * @param array $criteria
-     *
-     * @return array
-     */
-    protected function getCriteria(array $criteria = []): array
-    {
-        $criteria['source'] = $this->alias;
-        $criteria['sourceTable'] = $this->sourceTable;
-        $criteria['sourceField'] = $this->sourceField;
-
-        return $criteria;
     }
 }

--- a/src/Manager/DefaultManager.php
+++ b/src/Manager/DefaultManager.php
@@ -26,22 +26,22 @@ class DefaultManager implements ManagerInterface, DcaAwareInterface
     /**
      * @var string
      */
-    private $alias;
+    protected $alias;
 
     /**
      * @var ContaoFrameworkInterface
      */
-    private $framework;
+    protected $framework;
 
     /**
      * @var string
      */
-    private $sourceTable;
+    protected $sourceTable;
 
     /**
      * @var string
      */
-    private $sourceField;
+    protected $sourceField;
 
     /**
      * DefaultManager constructor.
@@ -190,7 +190,7 @@ class DefaultManager implements ManagerInterface, DcaAwareInterface
      *
      * @return array
      */
-    private function getCriteria(array $criteria = []): array
+    protected function getCriteria(array $criteria = []): array
     {
         $criteria['source'] = $this->alias;
         $criteria['sourceTable'] = $this->sourceTable;

--- a/src/Model/TagModel.php
+++ b/src/Model/TagModel.php
@@ -96,7 +96,7 @@ class TagModel extends Model
                 throw new NoTagsException();
             }
 
-            $columns[] = "alias IN ('" . implode("','", $criteria['aliases']) . "')";
+            $columns[] = "alias IN ('".implode("','", $criteria['aliases'])."')";
         }
 
         return [$columns, $values, $options];

--- a/src/Model/TagModel.php
+++ b/src/Model/TagModel.php
@@ -96,7 +96,7 @@ class TagModel extends Model
                 throw new NoTagsException();
             }
 
-            $columns[] = "alias IN ('".implode("','", $criteria['aliases'])."')";
+            $columns[] = "alias IN ('" . implode("','", $criteria['aliases']) . "')";
         }
 
         return [$columns, $values, $options];

--- a/src/Model/TagModel.php
+++ b/src/Model/TagModel.php
@@ -96,9 +96,7 @@ class TagModel extends Model
                 throw new NoTagsException();
             }
 
-            $columns[] = 'alias IN ('.implode(',', array_map(function($alias) {
-                return '"' . $alias . '"';
-                }, $criteria['aliases'])).')';
+            $columns[] = "alias IN ('".implode("','", $criteria['aliases'])."')";
         }
 
         return [$columns, $values, $options];

--- a/src/Model/TagModel.php
+++ b/src/Model/TagModel.php
@@ -90,6 +90,17 @@ class TagModel extends Model
             $columns[] = 'id IN ('.implode(',', array_map('intval', $criteria['values'])).')';
         }
 
+        // Find the tags by aliases
+        if (is_array($criteria['aliases'])) {
+            if (count($criteria['aliases']) < 1) {
+                throw new NoTagsException();
+            }
+
+            $columns[] = 'alias IN ('.implode(',', array_map(function($alias) {
+                return '"' . $alias . '"';
+                }, $criteria['aliases'])).')';
+        }
+
         return [$columns, $values, $options];
     }
 }

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -8,3 +8,7 @@ services:
         class: Codefog\TagsBundle\EventListener\DataContainer\TagListener
         arguments:
             - "@codefog_tags.manager_registry"
+    codefog_tags.listener.insert_tags:
+        class: Codefog\TagsBundle\EventListener\InsertTagsListener
+        arguments:
+            - "@contao.framework"

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -31,4 +31,4 @@ if (is_array($GLOBALS['TL_HOOKS']['loadDataContainer'])) {
     $GLOBALS['TL_HOOKS']['loadDataContainer'][] = ['codefog_tags.listener.tag_manager', 'onLoadDataContainer'];
 }
 
-$GLOBALS['TL_HOOKS']['replaceInsertTags']['codefog_tags.listener.insert_tags']  = ['codefog_tags.listener.insert_tags', 'onReplaceInsertTags'];
+$GLOBALS['TL_HOOKS']['replaceInsertTags']['codefog_tags.listener.insert_tags'] = ['codefog_tags.listener.insert_tags', 'onReplaceInsertTags'];

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -30,3 +30,5 @@ if (is_array($GLOBALS['TL_HOOKS']['loadDataContainer'])) {
 } else {
     $GLOBALS['TL_HOOKS']['loadDataContainer'][] = ['codefog_tags.listener.tag_manager', 'onLoadDataContainer'];
 }
+
+$GLOBALS['TL_HOOKS']['replaceInsertTags']['codefog_tags.listener.insert_tags']  = ['codefog_tags.listener.insert_tags', 'onReplaceInsertTags'];

--- a/src/Resources/contao/dca/tl_cfg_tag.php
+++ b/src/Resources/contao/dca/tl_cfg_tag.php
@@ -106,7 +106,7 @@ $GLOBALS['TL_DCA']['tl_cfg_tag'] = [
             'inputType' => 'text',
             'eval' => ['rgxp' => 'alias', 'unique' => true, 'maxlength' => 128, 'tl_class' => 'w50'],
             'save_callback' => [['codefog_tags.listener.data_container.tag', 'generateAlias']],
-            'sql' => "varchar(128) COLLATE utf8_bin NOT NULL default ''",
+            'sql' => ['type' => 'string', 'length' => 128, 'default' => ''],
         ],
         'source' => [
             'label' => &$GLOBALS['TL_LANG']['tl_cfg_tag']['source'],

--- a/src/Resources/contao/dca/tl_cfg_tag.php
+++ b/src/Resources/contao/dca/tl_cfg_tag.php
@@ -63,9 +63,16 @@ $GLOBALS['TL_DCA']['tl_cfg_tag'] = [
         ],
     ],
 
+    // Select
+    'select'      => [
+        'buttons_callback' => [
+            ['codefog_tags.listener.data_container.tag', 'addAliasButton']
+        ]
+    ],
+
     // Palettes
     'palettes' => [
-        'default' => '{name_legend},name,source',
+        'default' => '{name_legend},name,alias,source',
     ],
 
     // Fields
@@ -91,6 +98,15 @@ $GLOBALS['TL_DCA']['tl_cfg_tag'] = [
                 'tl_class' => 'w50',
             ],
             'sql' => ['type' => 'string', 'length' => 64, 'default' => ''],
+        ],
+        'alias' => [
+            'label'         => &$GLOBALS['TL_LANG']['tl_cfg_tag']['alias'],
+            'exclude'       => true,
+            'search'        => true,
+            'inputType'     => 'text',
+            'eval'          => ['rgxp' => 'alias', 'unique' => true, 'maxlength' => 128, 'tl_class' => 'w50'],
+            'save_callback' => [['codefog_tags.listener.data_container.tag', 'generateAlias']],
+            'sql'           => "varchar(128) COLLATE utf8_bin NOT NULL default ''",
         ],
         'source' => [
             'label' => &$GLOBALS['TL_LANG']['tl_cfg_tag']['source'],

--- a/src/Resources/contao/dca/tl_cfg_tag.php
+++ b/src/Resources/contao/dca/tl_cfg_tag.php
@@ -64,10 +64,10 @@ $GLOBALS['TL_DCA']['tl_cfg_tag'] = [
     ],
 
     // Select
-    'select'      => [
+    'select' => [
         'buttons_callback' => [
-            ['codefog_tags.listener.data_container.tag', 'addAliasButton']
-        ]
+            ['codefog_tags.listener.data_container.tag', 'addAliasButton'],
+        ],
     ],
 
     // Palettes
@@ -100,13 +100,13 @@ $GLOBALS['TL_DCA']['tl_cfg_tag'] = [
             'sql' => ['type' => 'string', 'length' => 64, 'default' => ''],
         ],
         'alias' => [
-            'label'         => &$GLOBALS['TL_LANG']['tl_cfg_tag']['alias'],
-            'exclude'       => true,
-            'search'        => true,
-            'inputType'     => 'text',
-            'eval'          => ['rgxp' => 'alias', 'unique' => true, 'maxlength' => 128, 'tl_class' => 'w50'],
+            'label' => &$GLOBALS['TL_LANG']['tl_cfg_tag']['alias'],
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'alias', 'unique' => true, 'maxlength' => 128, 'tl_class' => 'w50'],
             'save_callback' => [['codefog_tags.listener.data_container.tag', 'generateAlias']],
-            'sql'           => "varchar(128) COLLATE utf8_bin NOT NULL default ''",
+            'sql' => "varchar(128) COLLATE utf8_bin NOT NULL default ''",
         ],
         'source' => [
             'label' => &$GLOBALS['TL_LANG']['tl_cfg_tag']['source'],

--- a/src/Resources/contao/languages/de/modules.php
+++ b/src/Resources/contao/languages/de/modules.php
@@ -1,0 +1,11 @@
+<?php
+
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
+$GLOBALS['TL_LANG']['MOD']['cfg_tags'] = ['Schlagworte'];

--- a/src/Resources/contao/languages/de/tl_cfg_tag.php
+++ b/src/Resources/contao/languages/de/tl_cfg_tag.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
+$GLOBALS['TL_LANG']['tl_cfg_tag']['name'] = ['Name', 'Geben Sie hier einen Namen ein.'];
+$GLOBALS['TL_LANG']['tl_cfg_tag']['alias'] = ['Alias', 'Der Alias ist eine eindeutige Referenz, die anstelle der numerischen ID aufgerufen werden kann.'];
+$GLOBALS['TL_LANG']['tl_cfg_tag']['source'] = ['Quelle', 'Wählen Sie hier eine Quelle aus.'];
+$GLOBALS['TL_LANG']['tl_cfg_tag']['count'] = ['Globales Auftreten'];
+
+/*
+ * Legends
+ */
+$GLOBALS['TL_LANG']['tl_cfg_tag']['name_legend'] = 'Name und Quelle';
+
+/*
+ * Buttons
+ */
+$GLOBALS['TL_LANG']['tl_cfg_tag']['new'] = ['Neues Schlagwort', 'Ein neues Schlagwort erstellen'];
+$GLOBALS['TL_LANG']['tl_cfg_tag']['show'] = ['Schlagwort-Details', 'Schlagwort-Details ID %s anzeigen'];
+$GLOBALS['TL_LANG']['tl_cfg_tag']['edit'] = ['Schlagwort bearbeiten', 'Schlagwort ID %s bearbeiten'];
+$GLOBALS['TL_LANG']['tl_cfg_tag']['delete'] = ['Schlagwort löschen', 'Schlagwort ID %s löschen'];

--- a/src/Resources/contao/languages/en/tl_cfg_tag.php
+++ b/src/Resources/contao/languages/en/tl_cfg_tag.php
@@ -9,6 +9,7 @@
  */
 
 $GLOBALS['TL_LANG']['tl_cfg_tag']['name'] = ['Name', 'Please enter the tag name.'];
+$GLOBALS['TL_LANG']['tl_cfg_tag']['alias'] = ['Alias', 'The alias is a unique reference to the news item which can be called instead of its numeric ID.'];
 $GLOBALS['TL_LANG']['tl_cfg_tag']['source'] = ['Source', 'Please choose the tag source.'];
 $GLOBALS['TL_LANG']['tl_cfg_tag']['count'] = ['Total occurrences'];
 

--- a/tests/CodefogTagsBundleTest.php
+++ b/tests/CodefogTagsBundleTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test;
 
 use Codefog\TagsBundle\CodefogTagsBundle;

--- a/tests/Collection/ArrayCollectionTest.php
+++ b/tests/Collection/ArrayCollectionTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test\Collection;
 
 use Codefog\TagsBundle\Collection\ArrayCollection;

--- a/tests/Collection/ModelCollectionTest.php
+++ b/tests/Collection/ModelCollectionTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test\Collection;
 
 use Codefog\TagsBundle\Collection\ModelCollection;

--- a/tests/ContaoManager/PluginTest.php
+++ b/tests/ContaoManager/PluginTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test\ContaoManager;
 
 use Codefog\TagsBundle\CodefogTagsBundle;

--- a/tests/DependencyInjection/CodefogTagsExtensionTest.php
+++ b/tests/DependencyInjection/CodefogTagsExtensionTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
 
 namespace Codefog\TagsBundle\Test\DependencyInjection;
 

--- a/tests/DependencyInjection/Compiler/ManagerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ManagerPassTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
 
 namespace Codefog\TagsBundle\Test\DependencyInjection\Compiler;
 
@@ -44,9 +51,9 @@ class ManagerPassTest extends TestCase
         ]);
 
         $this->managerPass->process($container);
-        
+
         $calls = $registryDefinition->getMethodCalls();
-        
+
         static::assertEquals('add', $calls[0][0]);
         static::assertInstanceOf(Reference::class, $calls[0][1][0]);
         static::assertEquals('foo', $calls[0][1][1]);

--- a/tests/EventListener/DataContainer/TagListenerTest.php
+++ b/tests/EventListener/DataContainer/TagListenerTest.php
@@ -80,6 +80,8 @@ class TagListenerTest extends TestCase
                     });
 
                     return $activeRecord;
+                case 'id':
+                    return 1;
                 default:
                     return null;
             }
@@ -104,7 +106,7 @@ class TagListenerTest extends TestCase
             $this->listener->generateAlias('', $dc)
         );
 
-        // alias already existing
+        // alias already existing, none given
         $existingAliases = $this->createMock(Result::class);
 
         $existingAliases->method('__get')->willReturnCallback(function ($key) {
@@ -118,8 +120,16 @@ class TagListenerTest extends TestCase
 
         $this->listener->setExistingAliases($existingAliases);
 
-        // alias already existing, none given
-        $this->listener->generateAlias('', $dc);
+        static::assertEquals(
+            'my-example-alias-1',
+            $this->listener->generateAlias('', $dc)
+        );
+
+        // alias already existing
+        $this->listener->setExistingAliases($existingAliases);
+
+        $this->expectException('Exception');
+        $this->listener->generateAlias('my-example-alias', $dc);
     }
 
     public function testAddAliasButton()

--- a/tests/EventListener/DataContainer/TagListenerTest.php
+++ b/tests/EventListener/DataContainer/TagListenerTest.php
@@ -96,6 +96,24 @@ class TagListenerTest extends TestCase
             }
         });
 
+        // no existing alias
+        $this->listener->setExistingAliases($existingAliases);
+
+        static::assertEquals(
+            'my-example-alias',
+            $this->listener->generateAlias('', $dc)
+        );
+
+        // alias already existing
+        $existingAliases->method('__get')->willReturnCallback(function ($key) {
+            switch ($key) {
+                case 'numRows':
+                    return 1;
+                default:
+                    return null;
+            }
+        });
+
         $this->listener->setExistingAliases($existingAliases);
 
         static::assertEquals(

--- a/tests/EventListener/DataContainer/TagListenerTest.php
+++ b/tests/EventListener/DataContainer/TagListenerTest.php
@@ -14,12 +14,10 @@ use Codefog\TagsBundle\EventListener\DataContainer\TagListener;
 use Codefog\TagsBundle\Manager\ManagerInterface;
 use Codefog\TagsBundle\ManagerRegistry;
 use Codefog\TagsBundle\Tag;
-use Codefog\TagsBundle\Test\Fixtures\DummyModel;
-use Contao\CoreBundle\Tests\TestCase;
 use Contao\Database\Result;
 use Contao\DataContainer;
 use Contao\Model;
-use Contao\System;
+use PHPUnit\Framework\TestCase;
 
 class TagListenerTest extends TestCase
 {

--- a/tests/EventListener/DataContainer/TagListenerTest.php
+++ b/tests/EventListener/DataContainer/TagListenerTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test\EventListener\DataContainer;
 
 use Codefog\TagsBundle\EventListener\DataContainer\TagListener;
@@ -51,5 +59,18 @@ class TagListenerTest extends TestCase
     public function testGetSources()
     {
         static::assertEquals(['foo', 'bar'], $this->listener->getSources());
+    }
+
+    public function testGenerateAlias()
+    {
+        require_once __DIR__.'/../../Fixtures/Backend.php';
+
+        $dc = $this->createMock(DataContainer::class);
+        $dc->name = 'My example Alias';
+
+        static::assertEquals(
+            'my-example-alias',
+            $this->listener->generateAlias('', $this->createMock(DataContainer::class))
+        );
     }
 }

--- a/tests/EventListener/DataContainer/TagListenerTest.php
+++ b/tests/EventListener/DataContainer/TagListenerTest.php
@@ -19,7 +19,7 @@ use Contao\DataContainer;
 use Contao\Model;
 use PHPUnit\Framework\TestCase;
 
-class InsertTagsListenerTest extends TestCase
+class TagListenerTest extends TestCase
 {
     /**
      * @var TagListener
@@ -46,7 +46,7 @@ class InsertTagsListenerTest extends TestCase
 
     public function testGenerateLabel()
     {
-        require_once __DIR__ . '/../../Fixtures/Backend.php';
+        require_once __DIR__.'/../../Fixtures/Backend.php';
 
         static::assertNotEmpty(
             $this->listener->generateLabel(

--- a/tests/EventListener/DataContainer/TagListenerTest.php
+++ b/tests/EventListener/DataContainer/TagListenerTest.php
@@ -19,7 +19,7 @@ use Contao\DataContainer;
 use Contao\Model;
 use PHPUnit\Framework\TestCase;
 
-class TagListenerTest extends TestCase
+class InsertTagsListenerTest extends TestCase
 {
     /**
      * @var TagListener

--- a/tests/EventListener/DataContainer/TagListenerTest.php
+++ b/tests/EventListener/DataContainer/TagListenerTest.php
@@ -85,6 +85,7 @@ class TagListenerTest extends TestCase
             }
         });
 
+        // no existing alias
         $existingAliases = $this->createMock(Result::class);
 
         $existingAliases->method('__get')->willReturnCallback(function ($key) {
@@ -96,7 +97,6 @@ class TagListenerTest extends TestCase
             }
         });
 
-        // no existing alias
         $this->listener->setExistingAliases($existingAliases);
 
         static::assertEquals(
@@ -105,10 +105,12 @@ class TagListenerTest extends TestCase
         );
 
         // alias already existing
+        $existingAliases = $this->createMock(Result::class);
+
         $existingAliases->method('__get')->willReturnCallback(function ($key) {
             switch ($key) {
                 case 'numRows':
-                    return 1;
+                    return 2;
                 default:
                     return null;
             }
@@ -116,10 +118,8 @@ class TagListenerTest extends TestCase
 
         $this->listener->setExistingAliases($existingAliases);
 
-        static::assertEquals(
-            'my-example-alias',
-            $this->listener->generateAlias('', $dc)
-        );
+        // alias already existing, none given
+        $this->listener->generateAlias('', $dc);
     }
 
     public function testAddAliasButton()

--- a/tests/EventListener/DataContainer/TagListenerTest.php
+++ b/tests/EventListener/DataContainer/TagListenerTest.php
@@ -131,14 +131,4 @@ class TagListenerTest extends TestCase
         $this->expectException('Exception');
         $this->listener->generateAlias('my-example-alias', $dc);
     }
-
-    public function testAddAliasButton()
-    {
-        $dc = $this->createMock(DataContainer::class);
-
-        static::assertEquals(
-            ['alias' => '<button type="submit" name="alias" id="alias" class="tl_submit" accesskey="a"></button>'],
-            $this->listener->addAliasButton([], $dc)
-        );
-    }
 }

--- a/tests/EventListener/InsertTagsListenerTest.php
+++ b/tests/EventListener/InsertTagsListenerTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 
 class InsertTagsListenerTest extends TestCase
 {
-    /** @var  InsertTagsListener */
+    /** @var InsertTagsListener */
     protected $listener;
 
     protected function setUp()
@@ -34,9 +34,22 @@ class InsertTagsListenerTest extends TestCase
 
     public function testOnReplaceInsertTags()
     {
+        // id
         $this->assertSame(
             'The "foobar" tag',
-            $this->listener->onReplaceInsertTags('tags_title::2::1')
+            $this->listener->onReplaceInsertTags('tags_title::my-source::1')
+        );
+
+        // non-existing id
+        $this->assertSame(
+            'The "foobar" tag',
+            $this->listener->onReplaceInsertTags('tags_title::my-source::2')
+        );
+
+        // alias
+        $this->assertSame(
+            'The "foobar" tag',
+            $this->listener->onReplaceInsertTags('tags_title::my-source::my-alias')
         );
     }
 
@@ -72,6 +85,7 @@ class InsertTagsListenerTest extends TestCase
                         return null;
                 }
             });
+
             return $instance;
         });
 
@@ -83,7 +97,13 @@ class InsertTagsListenerTest extends TestCase
 
         $tagModelAdapter
             ->method('findByCriteria')
-            ->willReturn($noModels ? null : $tagModel);
+            ->willReturnCallback(function ($key) use ($tagModel) {
+                if ($key === ['values' => [2]]) {
+                    return null;
+                }
+
+                return $tagModel;
+            });
 
         $framework = $this->createMock(ContaoFrameworkInterface::class);
 

--- a/tests/EventListener/InsertTagsListenerTest.php
+++ b/tests/EventListener/InsertTagsListenerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
+namespace Codefog\TagsBundle\Test\EventListener;
+
+use Codefog\TagsBundle\EventListener\InsertTagsListener;
+use Codefog\TagsBundle\Model\TagModel;
+use Contao\CoreBundle\Framework\Adapter;
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\Model\Collection;
+use PHPUnit\Framework\TestCase;
+
+class InsertTagsListenerTest extends TestCase
+{
+    /** @var  InsertTagsListener */
+    protected $listener;
+
+    protected function setUp()
+    {
+        $this->listener = new InsertTagsListener($this->mockContaoFramework());
+    }
+
+    public function testInstantiation()
+    {
+        $this->assertInstanceOf(InsertTagsListener::class, $this->listener);
+    }
+
+    public function testOnReplaceInsertTags()
+    {
+        $this->assertSame(
+            'The "foobar" tag',
+            $this->listener->onReplaceInsertTags('tags_title::2::1')
+        );
+    }
+
+    public function testReturnsFalseIfTheTagIsUnknown()
+    {
+        $listener = new InsertTagsListener($this->mockContaoFramework());
+
+        $this->assertFalse($listener->onReplaceInsertTags('link_url::2'));
+    }
+
+    private function mockContaoFramework($source = 'default', $noModels = false)
+    {
+        $tagModel = $this->createMock(Collection::class);
+
+        $tagModel
+            ->method('__get')
+            ->willReturnCallback(function ($key) {
+                switch ($key) {
+                    case 'title':
+                        return 'The "foobar" tag';
+                    default:
+                        return null;
+                }
+            });
+
+        $tagModel->method('first')->willReturnCallback(function () {
+            $instance = $this->createMock(TagModel::class);
+            $instance->method('__get')->willReturnCallback(function ($key) {
+                switch ($key) {
+                    case 'name':
+                        return 'The "foobar" tag';
+                    default:
+                        return null;
+                }
+            });
+            return $instance;
+        });
+
+        $tagModelAdapter = $this
+            ->getMockBuilder(Adapter::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['findByCriteria'])
+            ->getMock();
+
+        $tagModelAdapter
+            ->method('findByCriteria')
+            ->willReturn($noModels ? null : $tagModel);
+
+        $framework = $this->createMock(ContaoFrameworkInterface::class);
+
+        $framework
+            ->method('isInitialized')
+            ->willReturn(true);
+
+        $framework
+            ->method('getAdapter')
+            ->willReturnCallback(function ($key) use ($tagModelAdapter) {
+                switch ($key) {
+                    case TagModel::class:
+                        return $tagModelAdapter;
+                    default:
+                        return null;
+                }
+            });
+
+        return $framework;
+    }
+}

--- a/tests/EventListener/TagManagerListenerTest.php
+++ b/tests/EventListener/TagManagerListenerTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test\EventListener;
 
 use Codefog\TagsBundle\EventListener\TagManagerListener;
@@ -76,7 +84,7 @@ class TagManagerListenerTest extends TestCase
 
         $GLOBALS['TL_DCA']['tl_table']['fields'] = [
             'field' => [
-                'eval' => ['tagsManager' => 'foobar']
+                'eval' => ['tagsManager' => 'foobar'],
             ],
         ];
 

--- a/tests/Fixtures/Backend.php
+++ b/tests/Fixtures/Backend.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 class Backend
 {
 }

--- a/tests/Fixtures/Controller.php
+++ b/tests/Fixtures/Controller.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 class Controller
 {
 }

--- a/tests/Fixtures/DcaExtractor.php
+++ b/tests/Fixtures/DcaExtractor.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 class DcaExtractor
 {
     public static function getInstance()

--- a/tests/Fixtures/DummyManager.php
+++ b/tests/Fixtures/DummyManager.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test\Fixtures;
 
 use Codefog\TagsBundle\Collection\CollectionInterface;

--- a/tests/Fixtures/DummyModel.php
+++ b/tests/Fixtures/DummyModel.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test\Fixtures;
 
 class DummyModel extends \Contao\Model

--- a/tests/Fixtures/ExtraDummyModel.php
+++ b/tests/Fixtures/ExtraDummyModel.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test\Fixtures;
 
 class ExtraDummyModel extends \Contao\Model

--- a/tests/Fixtures/Model.php
+++ b/tests/Fixtures/Model.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 class Model
 {
 }

--- a/tests/Manager/DefaultManagerTest.php
+++ b/tests/Manager/DefaultManagerTest.php
@@ -1,11 +1,17 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test\Manager;
 
 use Codefog\TagsBundle\Collection\CollectionInterface;
-use Codefog\TagsBundle\Collection\ModelCollection;
 use Codefog\TagsBundle\Manager\DefaultManager;
-use Codefog\TagsBundle\Model\TagModel;
 use Codefog\TagsBundle\Tag;
 use Codefog\TagsBundle\Test\Fixtures\DummyModel;
 use Codefog\TagsBundle\Test\Fixtures\ExtraDummyModel;
@@ -105,7 +111,7 @@ class DefaultManagerTest extends TestCase
                     'table' => 'tl_cfg_tag',
                 ],
                 'save_callback' => [
-                    ['codefog_tags.listener.tag_manager', 'onFieldSave']
+                    ['codefog_tags.listener.tag_manager', 'onFieldSave'],
                 ],
             ],
             $config

--- a/tests/ManagerRegistryTest.php
+++ b/tests/ManagerRegistryTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test;
 
 use Codefog\TagsBundle\Manager\ManagerInterface;

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
 namespace Codefog\TagsBundle\Test;
 
 use Codefog\TagsBundle\Tag;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+/** @var \Composer\Autoload\ClassLoader $loader */
+$loader = include_once __DIR__ . '/../../../autoload.php';
+
+$loader->addPsr4('Contao\\CoreBundle\\Tests\\', __DIR__ . '/../../../contao/core-bundle/tests');
+$loader->register();
+
+abstract class System extends \Contao\System {}
+abstract class Config extends \Contao\Config {}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,8 +3,5 @@
 /** @var \Composer\Autoload\ClassLoader $loader */
 $loader = include_once __DIR__ . '/../../../autoload.php';
 
-$loader->addPsr4('Contao\\CoreBundle\\Tests\\', __DIR__ . '/../../../contao/core-bundle/tests');
-$loader->register();
-
 abstract class System extends \Contao\System {}
 abstract class Config extends \Contao\Config {}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,18 @@
 <?php
 
-/** @var \Composer\Autoload\ClassLoader $loader */
-$loader = include_once __DIR__ . '/../../../autoload.php';
+/*
+ * Tags Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
 
-abstract class System extends \Contao\System {}
-abstract class Config extends \Contao\Config {}
+$loader = include_once __DIR__.'/../../../autoload.php';
+
+abstract class System extends \Contao\System
+{
+}
+abstract class Config extends \Contao\Config
+{
+}


### PR DESCRIPTION
Hi @qzminski ,

we just added an alias field to your tags_bundle and would very much appreciate it if you could merge the commit into the main project. The commit in detail contains:

- an alias field
- the necessary callbacks
- the global select option for batch generating aliases
- localization for English
- an insert tag called "tags_title" that outputs a tag's title by inserting a source name and the id or the alias of a tag

We also added the translation for German for all existing strings.