### PR TITLE
Fix PHP 8 warning in TagManagerListener.php

### DIFF
--- a/src/EventListener/TagManagerListener.php
+++ b/src/EventListener/TagManagerListener.php
@@ -111,9 +111,7 @@ class TagManagerListener
         $GLOBALS['TL_CSS'][] = Debug::uncompressedFile('bundles/codefogtags/backend.min.css');
 
         // Add the jQuery
-        if (!\in_array('assets/jquery/js/jquery.min.js', (array) $GLOBALS['TL_JAVASCRIPT'], true)
-            && !\in_array('assets/jquery/js/jquery.js', (array) $GLOBALS['TL_JAVASCRIPT'], true)
-        ) {
+        if (!isset($GLOBALS['TL_JAVASCRIPT']) || !preg_grep("/^assets\/jquery\/js\/jquery(\.min)?\.js$/", $GLOBALS['TL_JAVASCRIPT'])) {
             $GLOBALS['TL_JAVASCRIPT'][] = Debug::uncompressedFile('assets/jquery/js/jquery.min.js');
         }
 


### PR DESCRIPTION
When you use the tags bundle with PHP 8 in debug mode, you get a warning, that $GLOBALS['TL_JAVASCRIPT'] was not found. In PHP 7 it was just a notice that was ignored in debug mode.

![image](https://user-images.githubusercontent.com/87128053/151668347-816ec13d-91e3-465c-8b5a-ef169891949b.png)

The pull request contains a check for the $GLOBALS['TL_JAVASCRIPT'] and shortens the check for jquery.