### PR TITLE
Fix for DBAL 3 (Contao 4.13)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": "^7.1 || ^8.0",
         "ext-pdo": "*",
         "contao/core-bundle": "^4.4",
-        "codefog/contao-haste": "^4.24"
+        "codefog/contao-haste": "^4.24",
+        "doctrine/dbal": "^2.12 || ^3.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",

--- a/src/EventListener/DataContainer/TagListener.php
+++ b/src/EventListener/DataContainer/TagListener.php
@@ -88,7 +88,7 @@ class TagListener
         }
 
         // Append all other tags
-        foreach ($this->db->query("SELECT id FROM {$dc->table}")->fetchAll(PDO::FETCH_COLUMN, 0) as $id) {
+        foreach ($this->db->query("SELECT id FROM {$dc->table}")->fetchFirstColumn() as $id) {
             if (!\array_key_exists($id, $ids)) {
                 $ids[$id] = 0;
             }
@@ -274,7 +274,7 @@ class TagListener
             $value = StringUtil::generateAlias($dc->activeRecord->name);
         }
 
-        $exists = $this->db->fetchAll("SELECT id FROM {$dc->table} WHERE alias=? AND source=?", [$value, $dc->activeRecord->source]);
+        $exists = $this->db->fetchAllAssociative("SELECT id FROM {$dc->table} WHERE alias=? AND source=?", [$value, $dc->activeRecord->source]);
 
         // Check whether the record alias exists
         if (\count($exists) > 1 && !$autoAlias) {

--- a/src/EventListener/DataContainer/TagListener.php
+++ b/src/EventListener/DataContainer/TagListener.php
@@ -274,15 +274,15 @@ class TagListener
             $value = StringUtil::generateAlias($dc->activeRecord->name);
         }
 
-        $exists = $this->db->fetchAllAssociative("SELECT id FROM {$dc->table} WHERE alias=? AND source=?", [$value, $dc->activeRecord->source]);
+        $exists = $this->db->fetchOne("SELECT COUNT(*) FROM {$dc->table} WHERE alias=? AND source=?", [$value, $dc->activeRecord->source]);
 
         // Check whether the record alias exists
-        if (\count($exists) > 1 && !$autoAlias) {
+        if ($exists > 1 && !$autoAlias) {
             throw new \RuntimeException(sprintf($GLOBALS['TL_LANG']['ERR']['aliasExists'], $value));
         }
 
         // Add ID to alias
-        if (\count($exists) > 0 && $autoAlias) {
+        if ($exists > 0 && $autoAlias) {
             $value .= '-'.$dc->id;
         }
 

--- a/src/Finder/SourceFinder.php
+++ b/src/Finder/SourceFinder.php
@@ -97,7 +97,7 @@ class SourceFinder
         }
 
         $related = [];
-        $records = $this->db->fetchAll($query);
+        $records = $this->db->fetchAllAssociative($query);
 
         // Generate the related records
         foreach ($records as $record) {


### PR DESCRIPTION
I get some errors in backend of Contao 4.13 when I use the tags bundle.

![image](https://user-images.githubusercontent.com/87128053/151671375-cf878693-0715-411b-91fd-ae3f83a68fe6.png)

![image](https://user-images.githubusercontent.com/87128053/151671431-48615fec-840f-4ffd-90ff-b09ddc15e551.png)

This is because Contao 4.13 is using DBAL 3. I changed fetchAll to methods supported in the new version.