### PR TITLE
Use contao.slug to generate tag alias

### DIFF
--- a/src/EventListener/DataContainer/TagListener.php
+++ b/src/EventListener/DataContainer/TagListener.php
@@ -271,7 +271,8 @@ class TagListener
         // Generate alias if there is none
         if (!$value) {
             $autoAlias = true;
-            $value = StringUtil::generateAlias($dc->activeRecord->name);
+            $aliasOptions = \Contao\PageModel::findBytype('root')->id ?? [];
+            $value = System::getContainer()->get('contao.slug')->generate($dc->activeRecord->name, $aliasOptions);
         }
 
         $existingAliases = $this->db->fetchOne("SELECT COUNT(*) FROM {$dc->table} WHERE alias=? AND source=?", [$value, $dc->activeRecord->source]);

--- a/src/Manager/DefaultManager.php
+++ b/src/Manager/DefaultManager.php
@@ -20,6 +20,7 @@ use Codefog\TagsBundle\Model\TagModel;
 use Codefog\TagsBundle\Tag;
 use Contao\DataContainer;
 use Contao\StringUtil;
+use Contao\System;
 
 class DefaultManager implements ManagerInterface, DcaAwareInterface, InsertTagsAwareInterface
 {
@@ -299,7 +300,8 @@ class DefaultManager implements ManagerInterface, DcaAwareInterface, InsertTagsA
      */
     protected function generateAlias(TagModel $model, string $source = null): void
     {
-        $alias = StringUtil::generateAlias($model->name);
+        $aliasOptions = \Contao\PageModel::findBytype('root')->id ?? [];
+        $alias = System::getContainer()->get('contao.slug')->generate($model->name, $aliasOptions);
 
         // Add ID to alias if it already exists
         if (null !== ($existingTag = $this->tagFinder->findSingle($this->createTagCriteria($source)->setAlias($alias)))) {


### PR DESCRIPTION
In order to use tag aliases as a slug or URL query it makes sense to use contaos slug generator (defaults on [ausi/slug-generator](https://github.com/ausi/slug-generator)) instead of the StringUtil::generateAlias method.

"valid alias characters" and/or "language" of the root page will be used to generate the alias/slug:
'ASCII numbers and lowercase letters' and 'de' would convert "Äpfel" to "aepfel"