### PR TITLE
Add compatibility for `symfony/config` `7.x`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "ext-pdo": "*",
         "contao/core-bundle": "^4.13 || ^5.0",
         "codefog/contao-haste": "^5.0",
-        "doctrine/dbal": "^2.12 || ^3.0"
+        "doctrine/dbal": "^2.12 || ^3.0",
+        "symfony/config": "^5.4 || ^6.4 || ^7.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -20,7 +20,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('codefog_tags');
 


### PR DESCRIPTION
Contao 5.4+ will allow `symfony/config` `7.x` - but there the following error will occur: 

```
Symfony\Component\ErrorHandler\Error\FatalError:
Compile Error: Declaration of Codefog\TagsBundle\DependencyInjection\Configuration::getConfigTreeBuilder() must be compatible with Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder(): Symfony\Component\Config\Definition\Builder\TreeBuilder

  at vendor\codefog\tags-bundle\src\DependencyInjection\Configuration.php:23
```

This PR fixes that and also adds the missing dependency.