### PR TITLE
Fix broken alias where clause in TagFinder

### DIFF
--- a/src/Finder/TagFinder.php
+++ b/src/Finder/TagFinder.php
@@ -178,7 +178,7 @@ class TagFinder
                 $columns[] = 'alias=?';
                 $values[] = $aliases[0];
             } else {
-                $columns[] = "alias IN ('".implode("','", $aliases)."')'";
+                $columns[] = "alias IN ('".implode("','", $aliases)."')";
             }
         }
 


### PR DESCRIPTION
HI all,

first of all, thank you for developing and maintaining this extension!

I just ran into a malformed SQL query issue when quering the tags table by alias. The `alias in ()` WHERE clause has a superfluous aposttrophe at the end of the string. This PR fixes this.

Best
Benedict